### PR TITLE
Fix version file URL property

### DIFF
--- a/ReleaseFolder/GameData/WildBlueIndustries/Sandcastle/Sandcastle.version
+++ b/ReleaseFolder/GameData/WildBlueIndustries/Sandcastle/Sandcastle.version
@@ -1,6 +1,6 @@
 {
     "NAME":"Sandcastle",
-    "URL":"https://raw.githubusercontent.com/Angel-125/Sandcastle/master/ReleaseFolder/GameData/WildBlueIndustries/Sandcastle/Sandcastle.version",
+    "URL":"https://raw.githubusercontent.com/Angel-125/Sandcastle/main/ReleaseFolder/GameData/WildBlueIndustries/Sandcastle/Sandcastle.version",
     "DOWNLOAD":"https://github.com/Angel-125/Sandcastle/releases",
     "GITHUB":
     {


### PR DESCRIPTION
Hi @Angel-125!

The repo uses a `main` branch, but the version file has `master` instead.
This PR fixes it.

Cheers!