### PR TITLE
Update B9PS.cfg to make it compatible with SimpleConstruction!

### DIFF
--- a/ReleaseFolder/GameData/WildBlueIndustries/Sandcastle/Patches/B9PS.cfg
+++ b/ReleaseFolder/GameData/WildBlueIndustries/Sandcastle/Patches/B9PS.cfg
@@ -1,4 +1,4 @@
-@PART[rocketPartsContainerMid]:NEEDS[B9PartSwitch,Launchpad, !WildBlueTools]
+@PART[rocketPartsContainerMid]:NEEDS[B9PartSwitch,Launchpad,!WildBlueTools]
 {
 	@title = #LOC_SANDCASTLE_rocketPartsContainerMidELTitle
 	@description = #LOC_SANDCASTLE_rocketPartsContainerMidELDesc

--- a/ReleaseFolder/GameData/WildBlueIndustries/Sandcastle/Patches/B9PS.cfg
+++ b/ReleaseFolder/GameData/WildBlueIndustries/Sandcastle/Patches/B9PS.cfg
@@ -1,4 +1,4 @@
-@PART[rocketPartsContainerMid]:NEEDS[B9PartSwitch,Launchpad,!WildBlueTools]
+@PART[rocketPartsContainerMid]:NEEDS[B9PartSwitch,Launchpad, !WildBlueTools]
 {
 	@title = #LOC_SANDCASTLE_rocketPartsContainerMidELTitle
 	@description = #LOC_SANDCASTLE_rocketPartsContainerMidELDesc
@@ -27,7 +27,7 @@
 			title = #EL_Metal_displayName
 			tankType = scMetal
 		}
-		SUBTYPE
+		SUBTYPE:NEEDS[!SimpleConstruction]
 		{
 			name = scrapMetal
 			primaryColor = #d3d3d3
@@ -35,7 +35,15 @@
 			title = #EL_ScrapMetal_displayName
 			tankType = scScrapMetal
 		}
-		SUBTYPE
+		SUBTYPE:NEEDS[SimpleConstruction]
+		{
+			name = Ore
+			primaryColor = #caa472
+			secondaryColor = #caa472
+			title = #autoLOC_501007 = Ore
+			tankType = Ore
+		}
+		SUBTYPE:NEEDS[!SimpleConstruction]
 		{
 			name = metalOre
 			primaryColor = #caa472
@@ -70,7 +78,7 @@ B9_TANK_TYPE:NEEDS[B9PartSwitch,Launchpad,!WildBlueTools]
 	}
 }
 
-B9_TANK_TYPE:NEEDS[B9PartSwitch,Launchpad,!WildBlueTools]
+B9_TANK_TYPE:NEEDS[B9PartSwitch,Launchpad,!SimpleConstruction,!WildBlueTools]
 {
 	name = scScrapMetal
 	title = #EL_ScrapMetal_displayName


### PR DESCRIPTION
@Angel-125 👍 

# several issues this attempts to start to resolve

* SimpleConstruction! was already using `'SCMetal` and `SCRocketParts` for it's B9 Tank types. Not an issue if B9 is case insensitive.
* When SandCastle is installed with SimpleConstruction! B9PartSwitcher has a conniption and leaps overboard yelling and screaming taking the entire game with it.
* There is also a discrepancy in storage units...
* Might want to consider using SimpleConstruction!'s Resource Definitions/B9 Tank Types et al because has more information for each Resource and tanktype. That is when SimpleConstruction! is installed.
* should fix #3 - SimpleConstruction! Compatibility

will also post on the forums.