### PR TITLE
update txt for sandcastlecore - all ModuleScienceLab, no volume limit

### DIFF
--- a/ReleaseFolder/GameData/WildBlueIndustries/Sandcastle/Patches/ScienceLab3DPrinter.txt
+++ b/ReleaseFolder/GameData/WildBlueIndustries/Sandcastle/Patches/ScienceLab3DPrinter.txt
@@ -1,12 +1,12 @@
-// Adds the print shop and recycler to the stock science lab.
-@PART[Large_Crewed_Lab]
+// Adds the print shop and recycler to the ModuleScienceLab
+@PART:HAS[@MODULE[ModuleScienceLab],!MODULE[WBIPrintShop],!MODULE[WBICargoRecycler]]
 {
 	MODULE
 	{
 		name = WBIPrintShop
 
 		// The maximum volume that the printer can print, in liters. Set to less than 0 for no restrictions.
-		maxPrintVolume = 200
+		maxPrintVolume = -1
 
 		// The number of resource units per second that the printer can print.
 		printSpeedUSec = 1


### PR DESCRIPTION
Change ScienceLab3DPrinter.txt a little bit: instead of adding printer and recycler to the stock lab, the patch add them to all parts with the ModuleScienceLab, also VolumeLimit is disabled.

The txt file is renamed to the .cfg by the CKAN for the new SandcastleCore item in the CKAN