### PR TITLE
Fix: Restore coupled vessel UI state after quicksave/quickload

### DIFF
--- a/source/Sandcastle/PartModules/PrintShop/SCShipwright.cs
+++ b/source/Sandcastle/PartModules/PrintShop/SCShipwright.cs
@@ -106,6 +106,12 @@ namespace Sandcastle.PrintShop
             }
 
             part.StartCoroutine(InventoryUtils.decoupleVessel(dockedVesselRootPart, dockedVesselInfo, true));
+
+            // Clear the docked vessel info and update UI after decoupling
+            dockedVesselInfo = null;
+            shipwrightUI.showDecoupleButton = false;
+            shipwrightUI.showSpawnButton = false;
+            clearStats();
         }
 
         [KSPEvent(guiActive = true, groupName = "#LOC_SANDCASTLE_shipwrightGroupName", groupDisplayName = "#LOC_SANDCASTLE_shipwrightGroupName", guiName = "(Debug) Spawn Vessel")]

--- a/source/Sandcastle/PartModules/PrintShop/SCShipwright.cs
+++ b/source/Sandcastle/PartModules/PrintShop/SCShipwright.cs
@@ -141,9 +141,17 @@ namespace Sandcastle.PrintShop
                 shipwrightUI.craftName = shipName;
             }
 
-            if (finalizeVesselAtStartup)
+            // Restore coupled vessel UI state after reload
+            if (dockedVesselInfo != null)
             {
-                // If craft was coupled, show decouple button. Otherwise show finalize button.
+                shipwrightUI.showSpawnButton = false;
+                shipwrightUI.showDecoupleButton = true;
+                if (debugMode)
+                    Debug.Log("[Sandcastle] - Restored coupled vessel UI state on load");
+            }
+            else if (finalizeVesselAtStartup)
+            {
+                // Vessel is printed but not yet coupled, show spawn button
                 shipwrightUI.showSpawnButton = true;
 
                 // Show bounding box


### PR DESCRIPTION
When a printed vessel was coupled to the printer and the game was quicksaved/quickloaded, the UI would not reflect that the vessel was still coupled. The dockedVesselInfo was being saved and loaded correctly, but the UI state (decouple button visibility) was not being restored.

This fix adds logic in OnStart() to check if dockedVesselInfo exists after loading from save, and if so, restores the correct UI state by showing the decouple button. It uses else-if logic to properly separate the two states:
- Coupled vessel (dockedVesselInfo != null) -> show decouple button
- Printed but not coupled (finalizeVesselAtStartup) -> show spawn button