### PR TITLE
Preserve Ablator resources when 3D printing ships

### DIFF
--- a/source/Sandcastle/PartModules/Inventory/SupportClasses/InventoryUtils.cs
+++ b/source/Sandcastle/PartModules/Inventory/SupportClasses/InventoryUtils.cs
@@ -515,7 +515,8 @@ namespace Sandcastle.Inventory
                     int count = storedPart.snapshot.resources.Count;
                     for (int resourceIndex = 0; resourceIndex < count; resourceIndex++)
                     {
-                        if (storedPart.snapshot.resources[resourceIndex].resourceName == "ElectricCharge")
+                        if (storedPart.snapshot.resources[resourceIndex].resourceName == "ElectricCharge" ||
+                            storedPart.snapshot.resources[resourceIndex].resourceName == "Ablator")
                             continue;
                         storedPart.snapshot.resources[resourceIndex].amount = 0;
                     }
@@ -1204,7 +1205,7 @@ namespace Sandcastle.Inventory
                     for (int index = 0; index < resourceCount; index++)
                     {
                         resource = part.Resources[index];
-                        if (resource.resourceName != "ElectricCharge")
+                        if (resource.resourceName != "ElectricCharge" && resource.resourceName != "Ablator")
                             resource.amount = 0f;
                     }
                 }
@@ -1222,7 +1223,7 @@ namespace Sandcastle.Inventory
                     for (int index = 0; index < resourceCount; index++)
                     {
                         resourceSnapshot = protoPart.resources[index];
-                        if (resourceSnapshot.resourceName != "ElectricCharge")
+                        if (resourceSnapshot.resourceName != "ElectricCharge" && resourceSnapshot.resourceName != "Ablator")
                             resourceSnapshot.amount = 0;
                     }
                 }


### PR DESCRIPTION
Heat shields now retain their ablator when printed and added to inventory, similar to how ElectricCharge is already preserved. This ensures heat shields are printed with full ablator capacity.