### PR TITLE
Perf: Delete `InventoryUtils.FindThumbnailPaths`

### DIFF
--- a/source/Sandcastle/PartModules/Inventory/SupportClasses/InventoryUtils.cs
+++ b/source/Sandcastle/PartModules/Inventory/SupportClasses/InventoryUtils.cs
@@ -21,7 +21,6 @@ namespace Sandcastle.Inventory
         #endregion
 
         #region Housekeeping
-        static List<string> thumbnailFilePaths = null;
         static Dictionary<string, Texture2D> thumbnails = null;
         #endregion
 
@@ -596,36 +595,6 @@ namespace Sandcastle.Inventory
             }
 
             return filteredParts;
-        }
-
-        /// <summary>
-        /// Searches the game folder for thumbnail images.
-        /// </summary>
-        public static void FindThumbnailPaths()
-        {
-            string gameDataPath = Path.GetFullPath(Path.Combine(KSPUtil.ApplicationRootPath, "GameData"));
-            string[] files = Directory.GetFiles(gameDataPath, "*_icon*.png", SearchOption.AllDirectories);
-
-            thumbnailFilePaths = new List<string>();
-
-            for (int index = 0; index < files.Length; index++)
-            {
-                if (files[index].Contains("@thumbs"))
-                {
-                    thumbnailFilePaths.Add(files[index]);
-                }
-            }
-
-            // Don't forget the root path
-            gameDataPath = Path.GetFullPath(KSPUtil.ApplicationRootPath);
-            files = Directory.GetFiles(gameDataPath, "*_icon*.png", SearchOption.AllDirectories);
-            for (int index = 0; index < files.Length; index++)
-            {
-                if (files[index].Contains("@thumbs"))
-                {
-                    thumbnailFilePaths.Add(files[index]);
-                }
-            }
         }
 
         /// <summary>

--- a/source/Sandcastle/Scenario/SandcastleScenario.cs
+++ b/source/Sandcastle/Scenario/SandcastleScenario.cs
@@ -64,7 +64,6 @@ namespace Sandcastle
             if (HighLogic.LoadedSceneIsFlight)
             {
                 MaterialsList.LoadLists();
-                InventoryUtils.FindThumbnailPaths();
                 GameEvents.onAttemptEva.Add(onAttemptEVA);
                 GameEvents.OnGameSettingsApplied.Add(onGameSettingsApplied);
                 GameEvents.onVesselGoOffRails.Add(onVesselGoOffRails);


### PR DESCRIPTION
This method iterates over every single file in GameData during scene switch. On my install this one method contributes ~700ms to scene switch times.

As far as I can tell none of the outputs of this method are ever used. As such, this PR simply deletes the method and any calls to it.