### PR TITLE
Fix Survey Cone vessel name nesting

### DIFF
--- a/source/Sandcastle/PartModules/Inventory/ModulePartModuleFactory.cs
+++ b/source/Sandcastle/PartModules/Inventory/ModulePartModuleFactory.cs
@@ -69,8 +69,10 @@ namespace Sandcastle.PartModules.Inventory
                 addedPartModules.Add(moduleAdded);
                 loadModuleSettings(moduleAdded, 0);
             }
-            if (Vessel.IsValidVesselName(part.vessel.name))
-                GameEvents.onVesselRename.Fire(new GameEvents.HostedFromToAction<Vessel, string>(part.vessel, part.vessel.name, part.vessel.name));
+            // vessel.name is Unity's object name (for example, "partName (vesselName)").
+            string vesselName = part.vessel.vesselName;
+            if (Vessel.IsValidVesselName(vesselName))
+                GameEvents.onVesselRename.Fire(new GameEvents.HostedFromToAction<Vessel, string>(part.vessel, vesselName, vesselName));
         }
 
         public override void OnLoad(ConfigNode node)


### PR DESCRIPTION
## Summary

- use KSP's `Vessel.vesselName` when notifying `onVesselRename`
- avoid passing Unity's formatted object name into the vessel-rename event
- prevent Survey Cone vessel names from gaining another `elSurveyCone (...)` wrapper each time the runtime module factory starts

## Root cause

The Survey Cone delays adding `ELSurveyStake` until its vessel is loaded, then `ModulePartModuleFactory` rebroadcasts `onVesselRename` so the newly added module and other listeners see the vessel name.

That rebroadcast used `part.vessel.name`, which is Unity's object name and can be formatted like `elSurveyCone (Storage)`. Rename listeners can persist that formatted value as the KSP vessel name. On the next load, Unity formats the object name around the already-modified vessel name again, producing recursive names such as `elSurveyCone (elSurveyCone (Storage))`.

`Vessel.vesselName` is the actual KSP display and persistent vessel name expected by this event.

## Validation

- confirmed the live KSP log contains progressively nested Survey Cone vessel names
- confirmed the factory is used by the Survey Cone to add `ELSurveyStake` after vessel creation
- rebuilt the modified branch successfully against the installed KSP 1.12.5 assemblies
- `git diff --check` passes

This prevents additional nesting. It intentionally does not rewrite names that are already persisted in existing saves.
