### PR TITLE
Fix empty inventory detection and printer reload state

### DIFF
--- a/source/Sandcastle/PartModules/Inventory/SupportClasses/InventoryUtils.cs
+++ b/source/Sandcastle/PartModules/Inventory/SupportClasses/InventoryUtils.cs
@@ -66,7 +66,7 @@ namespace Sandcastle.Inventory
             {
                 inventory = inventories[index];
 
-                if (!inventory.isEnabled || inventory.InventoryIsFull || inventory.massCapacityReached || inventory.volumeCapacityReached || inventory.volumeCapacity <= 0)
+                if (!inventory.isEnabled || inventory.InventoryIsFull || inventory.massCapacityReached || inventory.volumeCapacityReached)
                     continue;
 
                 // Check mass
@@ -164,7 +164,7 @@ namespace Sandcastle.Inventory
             bool volRequirementMet = false;
             double partMass = availablePart.partPrefab.mass + availablePart.partPrefab.resourceMass;
 
-            if (!inventory.isEnabled || inventory.InventoryIsFull || inventory.massCapacityReached || inventory.volumeCapacityReached || inventory.volumeCapacity <= 0)
+            if (!inventory.isEnabled || inventory.InventoryIsFull || inventory.massCapacityReached || inventory.volumeCapacityReached)
                 return false;
 
             // Check mass
@@ -231,7 +231,7 @@ namespace Sandcastle.Inventory
             {
                 inventory = inventories[index];
 
-                if (!inventory.isEnabled || inventory.InventoryIsFull || inventory.massCapacityReached || inventory.volumeCapacityReached || inventory.volumeCapacity <= 0)
+                if (!inventory.isEnabled || inventory.InventoryIsFull || inventory.massCapacityReached || inventory.volumeCapacityReached)
                     continue;
 
                 // Check mass

--- a/source/Sandcastle/PartModules/PrintShop/SCBasePrinter.cs
+++ b/source/Sandcastle/PartModules/PrintShop/SCBasePrinter.cs
@@ -172,6 +172,7 @@ namespace Sandcastle.PrintShop
                 lastUpdateTime = Planetarium.GetUniversalTime();
                 printState = WBIPrintStates.Idle;
                 updateUIStatus(printState.ToString());
+                updateUIStatus(false);
                 part.Effect(runningEffect, 0);
                 if (animation != null)
                 {
@@ -219,6 +220,9 @@ namespace Sandcastle.PrintShop
             // Setup spawn transform
             if (!string.IsNullOrEmpty(spawnTransformName))
                 spawnTransform = part.FindModelTransform(spawnTransformName);
+
+            // Synchronize the UI with the restored printer state.
+            updateUIStatus(printState == WBIPrintStates.Printing);
         }
 
         public override void OnAwake()

--- a/source/Sandcastle/PartModules/PrintShop/WBIPrintShop.cs
+++ b/source/Sandcastle/PartModules/PrintShop/WBIPrintShop.cs
@@ -140,44 +140,6 @@ namespace Sandcastle.PrintShop
                 shopUI.SetVisible(false);
         }
 
-        public override void OnLoad(ConfigNode node)
-        {
-            base.OnLoad(node);
-
-            // Print state
-            if (node.HasValue(kPrintState))
-                printState = (WBIPrintStates)Enum.Parse(typeof(WBIPrintStates), node.GetValue(kPrintState));
-
-            // Print Queue
-            if (node.HasNode(BuildItem.kBuildItemNode))
-            {
-                BuildItem buildItem;
-                ConfigNode[] nodes = node.GetNodes(BuildItem.kBuildItemNode);
-                for (int index = 0; index < nodes.Length; index++)
-                {
-                    buildItem = new BuildItem(nodes[index]);
-                    printQueue.Add(buildItem);
-                }
-            }
-        }
-
-        public override void OnSave(ConfigNode node)
-        {
-            base.OnSave(node);
-
-            // Print state
-            node.AddValue(kPrintState, printState.ToString());
-
-            // Print queue
-            ConfigNode buildItemNode;
-            int count = printQueue.Count;
-            for (int index = 0; index < count; index++)
-            {
-                buildItemNode = printQueue[index].Save();
-                node.AddNode(buildItemNode);
-            }
-        }
-
         public override string GetInfo()
         {
             StringBuilder info = new StringBuilder();


### PR DESCRIPTION
## Summary

- allow stock `ModuleInventoryPart` inventories with zero occupied volume to be considered as print destinations
- let `WBIBasePrinter` own print-state and queue persistence exactly once
- synchronize the print-shop running UI after vessel reload and when the queue becomes empty

## Root cause

Sandcastle treated `volumeCapacity <= 0` as an unavailable inventory, but KSP reports an empty inventory with zero occupied volume through that field. Separately, `WBIPrintShop` duplicated its base class's `OnLoad` and `OnSave` logic, producing repeated `printState` and queue data. The restored/completed state also did not refresh the UI's boolean printing flag.

## Validation

- confirmed the empty-inventory change in-game
- built `Sandcastle.csproj` successfully with project references disabled
- inspected the compiled DLL: the derived print shop no longer declares duplicate persistence methods, and startup/completion call the boolean UI-state updater
- `git diff --check origin/main..HEAD`

Fixes #26
