### PR TITLE
Fix root-part printer UI queue binding

### DIFF
--- a/source/Sandcastle/PartModules/PrintShop/WBICargoRecycler.cs
+++ b/source/Sandcastle/PartModules/PrintShop/WBICargoRecycler.cs
@@ -220,6 +220,9 @@ namespace Sandcastle.PrintShop
         {
             base.OnLoad(node);
 
+            // KSP can replace the public queue during module load after OnAwake.
+            recyclerUI.recycleQueue = recycleQueue;
+
             // Recycle state
             if (node.HasValue(kRecycleState))
                 recycleState = (WBIPrintStates)Enum.Parse(typeof(WBIPrintStates), node.GetValue(kRecycleState));

--- a/source/Sandcastle/PartModules/PrintShop/WBIPrintShop.cs
+++ b/source/Sandcastle/PartModules/PrintShop/WBIPrintShop.cs
@@ -186,6 +186,9 @@ namespace Sandcastle.PrintShop
         {
             base.OnLoad(node);
 
+            // KSP can replace the public queue during module load after OnAwake.
+            shopUI.printQueue = printQueue;
+
             if (node.HasNode("DOCKED_PART_INFO"))
             {
                 dockedPartInfo = new DockedVesselInfo();

--- a/source/Sandcastle/PartModules/PrintShop/WBIShipwright.cs
+++ b/source/Sandcastle/PartModules/PrintShop/WBIShipwright.cs
@@ -537,6 +537,9 @@ namespace Sandcastle.PrintShop
         {
             base.OnLoad(node);
 
+            // KSP can replace the public queue during module load after OnAwake.
+            shipwrightUI.printQueue = printQueue;
+
             if (node.HasValue("shipName"))
                 shipName = node.GetValue("shipName");
 


### PR DESCRIPTION
## Summary

- rebind the part-printer and shipwright UIs to their loaded print queues
- rebind the cargo-recycler UI to its loaded recycle queue
- keep all existing queue contents, persistence, state transitions, and UI behavior unchanged

## Root cause

The module UIs capture their queue references during `OnAwake`. When a printer or recycler is the vessel's root part, KSP can replace the module's public queue while loading persistent module state afterward. The module then operates on the loaded queue while its UI can remain attached to the earlier list. Jobs added through that stale UI reference never reach the queue processed by the module, so the printer remains idle.

Rebinding each affected UI immediately after `base.OnLoad(node)` makes the UI use the queue instance that KSP finished loading. The assignments are idempotent and do not alter either list.

## Reproduction

1. Build and launch a vessel with the Sandcaster printer as the root part.
2. Open the printer UI and add a print job.
3. Observe that the job is displayed by the UI but the printer remains idle.

Before this change, the UI adds the job to its stale pre-load queue while the printer processes the queue restored during module loading.

## Scope

This updates `WBIPrintShop`, `WBIShipwright`, and `WBICargoRecycler`. `WBIShipbreaker` is intentionally unchanged because its UI queue is a separate composed list built from multiple internal queues.

## Validation

- built `Sandcastle.csproj` successfully against the installed KSP assemblies with project-reference builds and post-build deployment disabled
- `git diff --check`
- reviewed the branch as one focused commit directly on current upstream `main`
